### PR TITLE
Fixed spelling of "gzip"

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -22,7 +22,7 @@ export class TiledInflatePlugin extends plugin.Base {
          * @returns {Uint32Array} decoded and decompressed data
          */
         utils.inflateb64 = (data, format) => {
-            if (format === "gizp" || format === "zlib") {
+            if (format === "gzip" || format === "zlib") {
                 var output = pako.inflate(Base64.toUint8Array(data));
                 return new Uint32Array(output.buffer);
             } else {


### PR DESCRIPTION
I did not test whether gzip compression actually works with `pako.inflate`, but at least this spelling mistake would prevent "gzip" from being attempted at all. :-)